### PR TITLE
Fix code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "express": "^4.19.2",
     "mongoose": "^8.4.4",
     "request": "^2.88.2",
-    "uuid": "^11.0.3"
+    "uuid": "^11.0.3",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/server/routes/points.js
+++ b/server/routes/points.js
@@ -6,6 +6,13 @@ const router = express.Router();
 const request = require('request');
 const collegeData = require('../data/collegeCriteria.json');
 require('dotenv').config();
+const rateLimit = require('express-rate-limit');
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
 
 // Fetch redirected URL
 async function fetchRedirectedUrl(url) {
@@ -104,7 +111,7 @@ async function sendLogMessage(message, topic) {
 }
 
 // Handle POST request for tracking points
-router.post('/', async (req, res) => {
+router.post('/', limiter, async (req, res) => {
   // Clear cookie set by server
   if (req.cookies.lastUrl) {
     res.clearCookie('lastUrl');


### PR DESCRIPTION
Fixes [https://github.com/Guru-25/SkillRack-Tracker/security/code-scanning/1](https://github.com/Guru-25/SkillRack-Tracker/security/code-scanning/1)

To fix the problem, we will introduce rate limiting to the route handler to prevent abuse and potential denial-of-service attacks. We will use the `express-rate-limit` package to limit the number of requests that can be made to the route within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
