### PR TITLE
Fix code scanning alert no. 4: Missing CSRF middleware

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,10 +4,12 @@ const cookieParser = require('cookie-parser');
 const pointsRouter = require('./routes/points');
 // const certificateRouter = require('./routes/certificate');
 require('dotenv').config();
+const lusca = require('lusca');
 
 const app = express();
 app.use(cookieParser());
 app.use(express.json());
+app.use(lusca.csrf());
 
 const IS_RECORD_ENABLED = process.env.IS_RECORD_ENABLED === 'true';
 

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
     "mongoose": "^8.4.4",
     "request": "^2.88.2",
     "uuid": "^11.0.3",
-    "express-rate-limit": "^7.5.0"
+    "express-rate-limit": "^7.5.0",
+    "lusca": "^1.7.0"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/Guru-25/SkillRack-Tracker/security/code-scanning/4](https://github.com/Guru-25/SkillRack-Tracker/security/code-scanning/4)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package provides CSRF protection and can be easily integrated into the existing code. We will install the `lusca` package and use its CSRF middleware in the Express app.

1. Install the `lusca` package.
2. Import the `lusca` package in the `server/index.js` file.
3. Add the CSRF middleware to the Express app before defining the routes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
