### PR TITLE
Fix code scanning alert no. 3: Server-side request forgery

### DIFF
--- a/server/routes/points.js
+++ b/server/routes/points.js
@@ -118,10 +118,10 @@ router.post('/', limiter, async (req, res) => {
   }
 
   let { url } = req.body;
-  const allowedDomains = ['example.com', 'another-example.com']; // Add your allowed domains here
+  const allowedDomain = "www.skillrack.com";
   try {
     const parsedUrl = new URL(url);
-    if (!allowedDomains.includes(parsedUrl.hostname)) {
+    if (allowedDomain !== parsedUrl.hostname) {
       return res.status(400).json({ error: 'Invalid URL domain' });
     }
 

--- a/server/routes/points.js
+++ b/server/routes/points.js
@@ -122,6 +122,7 @@ router.post('/', limiter, async (req, res) => {
   try {
     const parsedUrl = new URL(url);
     if (allowedDomain !== parsedUrl.hostname) {
+      console.error(`Invalid URL: ${url}`);
       return res.status(400).json({ error: 'Invalid URL domain' });
     }
 

--- a/server/routes/points.js
+++ b/server/routes/points.js
@@ -118,7 +118,13 @@ router.post('/', limiter, async (req, res) => {
   }
 
   let { url } = req.body;
+  const allowedDomains = ['example.com', 'another-example.com']; // Add your allowed domains here
   try {
+    const parsedUrl = new URL(url);
+    if (!allowedDomains.includes(parsedUrl.hostname)) {
+      return res.status(400).json({ error: 'Invalid URL domain' });
+    }
+
     if (!url.includes('resume')) {
       url = await fetchRedirectedUrl(url);
       console.log("fetched");


### PR DESCRIPTION
Fixes [https://github.com/Guru-25/SkillRack-Tracker/security/code-scanning/3](https://github.com/Guru-25/SkillRack-Tracker/security/code-scanning/3)

To fix the SSRF vulnerability, we need to ensure that the `url` parameter is validated and restricted to a set of known, safe URLs or patterns. This can be achieved by implementing an allow-list of acceptable URLs or domains. Additionally, we should avoid using user input directly in constructing the URL for the HTTP request.

1. Create an allow-list of acceptable base URLs or domains.
2. Validate the `url` parameter against this allow-list before making the HTTP request.
3. If the `url` is not in the allow-list, reject the request with an appropriate error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
