### PR TITLE
Fix code scanning alert no. 5: Database query built from user-controlled sources

### DIFF
--- a/server/routes/points.js
+++ b/server/routes/points.js
@@ -141,7 +141,7 @@ router.post('/', limiter, async (req, res) => {
 
     if (IS_RECORD_ENABLED) {
       // Perform database operations before sending response
-      let user = await User.findOne({ id: data.id });
+      let user = await User.findOne({ id: { $eq: data.id } });
       const logMessage = `\`${data.name} (${data.dept}'${data.year.slice(-2)})\`\n\n\`(${data.codeTutor} x 0) + (${data.codeTrack} x 2) + (${data.codeTest} x 30) + (${data.dt} x 20) + (${data.dc} x 2) = ${data.points} (${data.percentage}%)\`\n\n`;
       if (data.name !== '') {
         if (!user) {


### PR DESCRIPTION
Fixes [https://github.com/Guru-25/SkillRack-Tracker/security/code-scanning/5](https://github.com/Guru-25/SkillRack-Tracker/security/code-scanning/5)

To fix the problem, we need to ensure that the `data.id` value is properly sanitized or validated before being used in the database query. The best way to fix this is to use a method that ensures the `data.id` is a literal value and not a query object. We can use the `$eq` operator to achieve this.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
